### PR TITLE
添加单IP多域名下httpdns的实践

### DIFF
--- a/httpdns_api_demo/HttpDNSApp/AppDelegate.m
+++ b/httpdns_api_demo/HttpDNSApp/AppDelegate.m
@@ -7,6 +7,7 @@
 //
 
 #import "AppDelegate.h"
+#import "MyCFHttpMessageURLProtocol.h"
 
 @interface AppDelegate ()
 
@@ -17,6 +18,7 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
+    [NSURLProtocol registerClass:[MyCFHttpMessageURLProtocol class]];
     return YES;
 }
 

--- a/httpdns_api_demo/HttpDNSApp/ViewController.m
+++ b/httpdns_api_demo/HttpDNSApp/ViewController.m
@@ -46,8 +46,7 @@
         }
     }
     
-    NSURLConnection* connection=[[NSURLConnection alloc] initWithRequest:_request delegate:self startImmediately:YES];
-    
+    [[NSURLConnection alloc] initWithRequest:_request delegate:self startImmediately:YES];
 }
 
 - (void)didReceiveMemoryWarning {

--- a/httpdns_api_demo/HttpDNSApp/ViewController.m
+++ b/httpdns_api_demo/HttpDNSApp/ViewController.m
@@ -30,6 +30,8 @@
     // 为HTTPDNS服务设置降级机制
     [[HttpDNS instance] setDelegateForDegradationFilter:(id<HttpDNSDegradationDelegate>)self];
     NSString *originalUrl = @"https://dou.bz/23o8PS";
+//    NSString* originalUrl=@"https://book.douban.com/annual2015/#2";
+//    NSString* originalUrl=@"https://www.aliyun.com";
     NSURL* url = [NSURL URLWithString:originalUrl];
     self.request = [[NSMutableURLRequest alloc] initWithURL:url];
     NSString* ip = [[HttpDNS instance] getIpByHost:url.host];
@@ -40,13 +42,6 @@
         if (NSNotFound != hostFirstRange.location) {
             NSString* newUrl = [originalUrl stringByReplacingCharactersInRange:hostFirstRange withString:ip];
             self.request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:newUrl]];
-            NSMutableData* mutableData=[NSMutableData dataWithLength:100];
-            NSInputStream* instream=[NSInputStream inputStreamWithData:mutableData];
-            NSDictionary *sslSettings =[NSDictionary dictionaryWithObjectsAndKeys:url.host,(__bridge id)kCFStreamSSLPeerName, nil];
-            [instream setProperty:sslSettings forKey:(__bridge NSString*)kCFStreamPropertySSLSettings];
-            [instream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
-            [instream open];
-            [self.request setHTTPBodyStream:instream];
             [self.request setValue:url.host forHTTPHeaderField:@"host"];
         }
     }
@@ -157,7 +152,7 @@
     return (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
 }
 -(void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data{
-//    NSLog(@"receive data:%@",data);
+    NSLog(@"receive data:%@",[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
 }
 -(void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response{
     NSLog(@"receive response:%@",response);

--- a/httpdns_api_demo/HttpDNSApp/ViewController.m
+++ b/httpdns_api_demo/HttpDNSApp/ViewController.m
@@ -46,14 +46,7 @@
         }
     }
     
-//    NSHTTPURLResponse* response;
-//    Method originalMethod=class_getInstanceMethod([NSURLConnection class], @selector(connection:willSendRequestForAuthenticationChallenge:));
-//    Method swappedMethod=class_getInstanceMethod([NSURLConnection class], @selector(hda_connection:willSendRequestForAuthenticationChallenge:));
-//    method_exchangeImplementations(originalMethod, swappedMethod);
     NSURLConnection* connection=[[NSURLConnection alloc] initWithRequest:_request delegate:self startImmediately:YES];
-//    NSData* data = [NSURLConnection sendSynchronousRequest:self.request returningResponse:&response error:nil];
-    
-//    NSLog(@"response %@",response);
     
 }
 
@@ -82,75 +75,6 @@
     return NO;
 }
 
--(void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge{
-    if (!challenge) {
-        return;
-    }
-    
-    /*
-     * URL里面的host在使用HTTPDNS的情况下被设置成了IP，此处从HTTP Header中获取真实域名
-     */
-    NSString* host = [[self.request allHTTPHeaderFields] objectForKey:@"host"];
-    if (!host) {
-        host = self.request.URL.host;
-    }
-    
-    /*
-     * 判断challenge的身份验证方法是否是NSURLAuthenticationMethodServerTrust（HTTPS模式下会进行该身份验证流程），
-     * 在没有配置身份验证方法的情况下进行默认的网络请求流程。
-     */
-    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
-    {
-        if ([self evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:host]) {
-            /*
-             * 验证完以后，需要构造一个NSURLCredential发送给发起方
-             */
-            NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
-            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
-        } else {
-//            /*
-//             * 验证失败，取消这次验证流程
-//             */
-            [[challenge sender] cancelAuthenticationChallenge:challenge];
-        }
-    } else {
-        /*
-         * 对于其他验证方法直接进行处理流程
-         */
-        [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
-    }
-}
-- (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust
-                  forDomain:(NSString *)domain
-{
-//    domain=@"book.douban.com";
-    /*
-     * 创建证书校验策略
-     */
-    NSMutableArray *policies = [NSMutableArray array];
-    if (domain) {
-        [policies addObject:(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)domain)];
-    } else {
-        [policies addObject:(__bridge_transfer id)SecPolicyCreateBasicX509()];
-    }
-    
-    /*
-     * 绑定校验策略到服务端的证书上
-     */
-    SecTrustSetPolicies(serverTrust, (__bridge CFArrayRef)policies);
-    
-    
-    /*
-     * 评估当前serverTrust是否可信任，
-     * 官方建议在result = kSecTrustResultUnspecified 或 kSecTrustResultProceed
-     * 的情况下serverTrust可以被验证通过，https://developer.apple.com/library/ios/technotes/tn2232/_index.html
-     * 关于SecTrustResultType的详细信息请参考SecTrust.h
-     */
-    SecTrustResultType result;
-    SecTrustEvaluate(serverTrust, &result);
-    
-    return (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
-}
 -(void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data{
     NSLog(@"receive data:%@",[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
 }

--- a/httpdns_api_demo/HttpDNSApp/ViewController.m
+++ b/httpdns_api_demo/HttpDNSApp/ViewController.m
@@ -11,10 +11,12 @@
 
 #import "NetworkManager.h"
 #import "HttpDNSLog.h"
+//#import "NSURLConnection+HttpsExtension.h"
 #import "HttpDNS.h"
+#import <objc/runtime.h>
 
-@interface ViewController ()
-
+@interface ViewController ()<NSURLConnectionDelegate,NSURLConnectionDataDelegate>
+@property(strong,nonatomic)NSMutableURLRequest* request;
 @end
 
 @implementation ViewController
@@ -27,10 +29,9 @@
     [HttpDNSLog turnOnDebug];
     // 为HTTPDNS服务设置降级机制
     [[HttpDNS instance] setDelegateForDegradationFilter:(id<HttpDNSDegradationDelegate>)self];
-    NSString *originalUrl = @"http://www.aliyun.com/";
+    NSString *originalUrl = @"https://dou.bz/23o8PS";
     NSURL* url = [NSURL URLWithString:originalUrl];
-    NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:url];
-    
+    self.request = [[NSMutableURLRequest alloc] initWithURL:url];
     NSString* ip = [[HttpDNS instance] getIpByHost:url.host];
     // 通过HTTPDNS获取IP成功，进行URL替换和HOST头设置
     if (ip) {
@@ -38,14 +39,27 @@
         NSRange hostFirstRange = [originalUrl rangeOfString: url.host];
         if (NSNotFound != hostFirstRange.location) {
             NSString* newUrl = [originalUrl stringByReplacingCharactersInRange:hostFirstRange withString:ip];
-            request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:newUrl]];
-            [request setValue:url.host forHTTPHeaderField:@"host"];
+            self.request = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:newUrl]];
+            NSMutableData* mutableData=[NSMutableData dataWithLength:100];
+            NSInputStream* instream=[NSInputStream inputStreamWithData:mutableData];
+            NSDictionary *sslSettings =[NSDictionary dictionaryWithObjectsAndKeys:url.host,(__bridge id)kCFStreamSSLPeerName, nil];
+            [instream setProperty:sslSettings forKey:(__bridge NSString*)kCFStreamPropertySSLSettings];
+            [instream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
+            [instream open];
+            [self.request setHTTPBodyStream:instream];
+            [self.request setValue:url.host forHTTPHeaderField:@"host"];
         }
     }
-
-    NSHTTPURLResponse* response;
-    NSData* data = [NSURLConnection sendSynchronousRequest:request returningResponse:&response error:nil];
-    NSLog(@"response %@",response);
+    
+//    NSHTTPURLResponse* response;
+//    Method originalMethod=class_getInstanceMethod([NSURLConnection class], @selector(connection:willSendRequestForAuthenticationChallenge:));
+//    Method swappedMethod=class_getInstanceMethod([NSURLConnection class], @selector(hda_connection:willSendRequestForAuthenticationChallenge:));
+//    method_exchangeImplementations(originalMethod, swappedMethod);
+    NSURLConnection* connection=[[NSURLConnection alloc] initWithRequest:_request delegate:self startImmediately:YES];
+//    NSData* data = [NSURLConnection sendSynchronousRequest:self.request returningResponse:&response error:nil];
+    
+//    NSLog(@"response %@",response);
+    
 }
 
 - (void)didReceiveMemoryWarning {
@@ -73,4 +87,79 @@
     return NO;
 }
 
+-(void)connection:(NSURLConnection *)connection willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge{
+    if (!challenge) {
+        return;
+    }
+    
+    /*
+     * URL里面的host在使用HTTPDNS的情况下被设置成了IP，此处从HTTP Header中获取真实域名
+     */
+    NSString* host = [[self.request allHTTPHeaderFields] objectForKey:@"host"];
+    if (!host) {
+        host = self.request.URL.host;
+    }
+    
+    /*
+     * 判断challenge的身份验证方法是否是NSURLAuthenticationMethodServerTrust（HTTPS模式下会进行该身份验证流程），
+     * 在没有配置身份验证方法的情况下进行默认的网络请求流程。
+     */
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
+    {
+        if ([self evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:host]) {
+            /*
+             * 验证完以后，需要构造一个NSURLCredential发送给发起方
+             */
+            NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+        } else {
+//            /*
+//             * 验证失败，取消这次验证流程
+//             */
+            [[challenge sender] cancelAuthenticationChallenge:challenge];
+        }
+    } else {
+        /*
+         * 对于其他验证方法直接进行处理流程
+         */
+        [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+    }
+}
+- (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust
+                  forDomain:(NSString *)domain
+{
+//    domain=@"book.douban.com";
+    /*
+     * 创建证书校验策略
+     */
+    NSMutableArray *policies = [NSMutableArray array];
+    if (domain) {
+        [policies addObject:(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)domain)];
+    } else {
+        [policies addObject:(__bridge_transfer id)SecPolicyCreateBasicX509()];
+    }
+    
+    /*
+     * 绑定校验策略到服务端的证书上
+     */
+    SecTrustSetPolicies(serverTrust, (__bridge CFArrayRef)policies);
+    
+    
+    /*
+     * 评估当前serverTrust是否可信任，
+     * 官方建议在result = kSecTrustResultUnspecified 或 kSecTrustResultProceed
+     * 的情况下serverTrust可以被验证通过，https://developer.apple.com/library/ios/technotes/tn2232/_index.html
+     * 关于SecTrustResultType的详细信息请参考SecTrust.h
+     */
+    SecTrustResultType result;
+    SecTrustEvaluate(serverTrust, &result);
+    
+    return (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
+}
+-(void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data{
+//    NSLog(@"receive data:%@",data);
+}
+-(void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response{
+    NSLog(@"receive response:%@",response);
+}
 @end

--- a/httpdns_api_demo/httpdns_api_demo.xcodeproj/project.pbxproj
+++ b/httpdns_api_demo/httpdns_api_demo.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		C5767C651D04781E00765B8C /* NSURLConnection+HttpsExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = C5767C631D04781E00765B8C /* NSURLConnection+HttpsExtension.h */; };
 		C5767C661D04781E00765B8C /* NSURLConnection+HttpsExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = C5767C641D04781E00765B8C /* NSURLConnection+HttpsExtension.m */; };
+		F780478E1D124283000E4B52 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F780478D1D124283000E4B52 /* CFNetwork.framework */; };
+		F7BF49AF1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = F7BF49AE1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.m */; };
 		F7F2791E1BE24EA50094EF7D /* httpdns_api_demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7F279131BE24EA50094EF7D /* httpdns_api_demo.framework */; };
 		F7F279231BE24EA50094EF7D /* httpdns_api_demoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F279221BE24EA50094EF7D /* httpdns_api_demoTests.m */; };
 		F7F279301BE24FCA0094EF7D /* HttpDNS.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F2792E1BE24FCA0094EF7D /* HttpDNS.h */; };
@@ -55,6 +57,9 @@
 		946A9EFD1C50CFA000D5C1C8 /* HttpDNSDegradationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HttpDNSDegradationDelegate.h; sourceTree = "<group>"; };
 		C5767C631D04781E00765B8C /* NSURLConnection+HttpsExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLConnection+HttpsExtension.h"; sourceTree = "<group>"; };
 		C5767C641D04781E00765B8C /* NSURLConnection+HttpsExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLConnection+HttpsExtension.m"; sourceTree = "<group>"; };
+		F780478D1D124283000E4B52 /* CFNetwork.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
+		F7BF49AD1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MyCFHttpMessageURLProtocol.h; path = httpdns_api_demo/source/MyCFHttpMessageURLProtocol.h; sourceTree = SOURCE_ROOT; };
+		F7BF49AE1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MyCFHttpMessageURLProtocol.m; path = httpdns_api_demo/source/MyCFHttpMessageURLProtocol.m; sourceTree = SOURCE_ROOT; };
 		F7F279131BE24EA50094EF7D /* httpdns_api_demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = httpdns_api_demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7F279181BE24EA50094EF7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F7F2791D1BE24EA50094EF7D /* httpdns_api_demo.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = httpdns_api_demo.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -88,6 +93,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F780478E1D124283000E4B52 /* CFNetwork.framework in Frameworks */,
 				F7F279791BE2806D0094EF7D /* UIKit.framework in Frameworks */,
 				F7F279771BE280630094EF7D /* SystemConfiguration.framework in Frameworks */,
 				F7F279751BE280560094EF7D /* CoreTelephony.framework in Frameworks */,
@@ -119,6 +125,7 @@
 		F7F279091BE24EA50094EF7D = {
 			isa = PBXGroup;
 			children = (
+				F780478D1D124283000E4B52 /* CFNetwork.framework */,
 				F7F279781BE2806D0094EF7D /* UIKit.framework */,
 				F7F279761BE280630094EF7D /* SystemConfiguration.framework */,
 				F7F279741BE280560094EF7D /* CoreTelephony.framework */,
@@ -178,6 +185,8 @@
 		F7F2793F1BE27E660094EF7D /* HttpDNSApp */ = {
 			isa = PBXGroup;
 			children = (
+				F7BF49AD1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.h */,
+				F7BF49AE1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.m */,
 				F7F279431BE27E660094EF7D /* AppDelegate.h */,
 				F7F279441BE27E660094EF7D /* AppDelegate.m */,
 				F7F279461BE27E660094EF7D /* ViewController.h */,
@@ -364,6 +373,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7BF49AF1D100AA0007BB0BF /* MyCFHttpMessageURLProtocol.m in Sources */,
 				F7F279481BE27E660094EF7D /* ViewController.m in Sources */,
 				F7F279451BE27E660094EF7D /* AppDelegate.m in Sources */,
 				F7F279421BE27E660094EF7D /* main.m in Sources */,

--- a/httpdns_api_demo/httpdns_api_demo.xcodeproj/project.pbxproj
+++ b/httpdns_api_demo/httpdns_api_demo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C5767C651D04781E00765B8C /* NSURLConnection+HttpsExtension.h in Headers */ = {isa = PBXBuildFile; fileRef = C5767C631D04781E00765B8C /* NSURLConnection+HttpsExtension.h */; };
+		C5767C661D04781E00765B8C /* NSURLConnection+HttpsExtension.m in Sources */ = {isa = PBXBuildFile; fileRef = C5767C641D04781E00765B8C /* NSURLConnection+HttpsExtension.m */; };
 		F7F2791E1BE24EA50094EF7D /* httpdns_api_demo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7F279131BE24EA50094EF7D /* httpdns_api_demo.framework */; };
 		F7F279231BE24EA50094EF7D /* httpdns_api_demoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F279221BE24EA50094EF7D /* httpdns_api_demoTests.m */; };
 		F7F279301BE24FCA0094EF7D /* HttpDNS.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F2792E1BE24FCA0094EF7D /* HttpDNS.h */; };
@@ -51,6 +53,8 @@
 
 /* Begin PBXFileReference section */
 		946A9EFD1C50CFA000D5C1C8 /* HttpDNSDegradationDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HttpDNSDegradationDelegate.h; sourceTree = "<group>"; };
+		C5767C631D04781E00765B8C /* NSURLConnection+HttpsExtension.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLConnection+HttpsExtension.h"; sourceTree = "<group>"; };
+		C5767C641D04781E00765B8C /* NSURLConnection+HttpsExtension.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLConnection+HttpsExtension.m"; sourceTree = "<group>"; };
 		F7F279131BE24EA50094EF7D /* httpdns_api_demo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = httpdns_api_demo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7F279181BE24EA50094EF7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F7F2791D1BE24EA50094EF7D /* httpdns_api_demo.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = httpdns_api_demo.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -165,6 +169,8 @@
 				F7F279361BE271AC0094EF7D /* NetworkManager.h */,
 				F7F279371BE271AC0094EF7D /* NetworkManager.m */,
 				946A9EFD1C50CFA000D5C1C8 /* HttpDNSDegradationDelegate.h */,
+				C5767C631D04781E00765B8C /* NSURLConnection+HttpsExtension.h */,
+				C5767C641D04781E00765B8C /* NSURLConnection+HttpsExtension.m */,
 			);
 			path = source;
 			sourceTree = "<group>";
@@ -202,6 +208,7 @@
 			files = (
 				F7F279381BE271AC0094EF7D /* NetworkManager.h in Headers */,
 				F7F2797F1BE3401B0094EF7D /* HttpDNSLog.h in Headers */,
+				C5767C651D04781E00765B8C /* NSURLConnection+HttpsExtension.h in Headers */,
 				F7F279341BE250590094EF7D /* HttpDNSOrigin.h in Headers */,
 				F7F279301BE24FCA0094EF7D /* HttpDNS.h in Headers */,
 			);
@@ -339,6 +346,7 @@
 			files = (
 				F7F279311BE24FCA0094EF7D /* HttpDNS.m in Sources */,
 				F7F279391BE271AC0094EF7D /* NetworkManager.m in Sources */,
+				C5767C661D04781E00765B8C /* NSURLConnection+HttpsExtension.m in Sources */,
 				F7F279801BE3401B0094EF7D /* HttpDNSLog.m in Sources */,
 				F7F279351BE250590094EF7D /* HttpDNSOrigin.m in Sources */,
 			);

--- a/httpdns_api_demo/httpdns_api_demo/source/HttpDNS.m
+++ b/httpdns_api_demo/httpdns_api_demo/source/HttpDNS.m
@@ -12,7 +12,7 @@
 
 static BOOL isExpiredIpAvailable = YES;
 static NSString* defaultServerIP = @"203.107.1.1";
-static NSString* defaultAccountID = @"100000";
+static NSString* defaultAccountID = @"139450";
 static int defaultHostTTL = 30;
 
 @implementation HttpDNS

--- a/httpdns_api_demo/httpdns_api_demo/source/MyCFHttpMessageURLProtocol.h
+++ b/httpdns_api_demo/httpdns_api_demo/source/MyCFHttpMessageURLProtocol.h
@@ -1,0 +1,13 @@
+//
+//  MyCFHttpMessageURLProtocol.h
+//  NSURLProtocolDemo
+//
+//  Created by fuyuan.lfy on 16/6/14.
+//  Copyright © 2016年 Jaylon. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MyCFHttpMessageURLProtocol : NSURLProtocol
+
+@end

--- a/httpdns_api_demo/httpdns_api_demo/source/MyCFHttpMessageURLProtocol.m
+++ b/httpdns_api_demo/httpdns_api_demo/source/MyCFHttpMessageURLProtocol.m
@@ -145,6 +145,8 @@
             }
         }
         [self startRequest];
+    }else{
+        [self.client URLProtocol:self didLoadData:responseData];
     }
 //    NSLog(@"response is: %@",[[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding]);
 }
@@ -208,6 +210,7 @@
         [_inputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
         [_inputStream setDelegate:nil];
         [_inputStream close];
+        //通知nsurlconnection发生错误了
         NSError *underlyingError = CFBridgingRelease(CFReadStreamCopyError((CFReadStreamRef)_inputStream));
         [self.client URLProtocol:self didFailWithError:underlyingError];
     }else if(eventCode==NSStreamEventEndEncountered){

--- a/httpdns_api_demo/httpdns_api_demo/source/MyCFHttpMessageURLProtocol.m
+++ b/httpdns_api_demo/httpdns_api_demo/source/MyCFHttpMessageURLProtocol.m
@@ -1,0 +1,237 @@
+//
+//  MyCFHttpMessageURLProtocol.m
+//  NSURLProtocolDemo
+//
+//  Created by fuyuan.lfy on 16/6/14.
+//  Copyright © 2016年 Jaylon. All rights reserved.
+//
+
+#import "MyCFHttpMessageURLProtocol.h"
+#import "HttpDNS.h"
+#import "HttpDNSLog.h"
+#import "NetworkManager.h"
+
+#define protocolKey @"CFHttpMessagePropertyKey"
+#define kAnchorAlreadyAdded @"AnchorAlreadyAdded"
+
+@interface MyCFHttpMessageURLProtocol()<NSStreamDelegate>{
+    NSMutableData* responseData;
+    NSMutableURLRequest* curRequest;
+}
+
+@property(strong,nonatomic)NSInputStream* inputStream;
+
+@end
+
+@implementation MyCFHttpMessageURLProtocol
+
+/**
+ *  是否拦截处理指定的请求
+ *
+ *  @param request 指定的请求
+ *
+ *  @return 返回YES表示要拦截处理，返回NO表示不拦截处理
+ */
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+    
+    /*
+     防止无限循环，因为一个请求在被拦截处理过程中，也会发起一个请求，这样又会走到这里，如果不进行处理，就会造成无限循环
+     */
+    if ([NSURLProtocol propertyForKey:protocolKey inRequest:request]) {
+        return NO;
+    }
+    
+    NSString * url = request.URL.absoluteString;
+    
+    // 如果url已http或https开头，则进行拦截处理，否则不处理
+    if ([url hasPrefix:@"https"]) {
+        return YES;
+    }
+    return NO;
+}
+
+/**
+ *  如果需要对请求进行重定向，添加指定头部等操作，可以在该方法中进行
+ *
+ *  @param request 原请求
+ *
+ *  @return 修改后的请求
+ */
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+    return request;
+}
+
+-(void)startRequest{
+    CFStringRef requestHeader=CFSTR("host");
+    CFStringRef requestHeaderValue=(__bridge CFStringRef)[[curRequest allHTTPHeaderFields] valueForKey:@"host"];
+    CFStringRef requestBody=CFSTR("");
+    CFDataRef bodyData=CFStringCreateExternalRepresentation(kCFAllocatorDefault, requestBody, kCFStringEncodingUTF8, 0);
+    
+    CFStringRef url=(__bridge CFStringRef)[curRequest.URL absoluteString];
+    CFStringRef requestMethod=(__bridge_retained CFStringRef)curRequest.HTTPMethod;
+    CFURLRef requestURL=CFURLCreateWithString(kCFAllocatorDefault, url, NULL);
+    CFHTTPMessageRef cfrequest=CFHTTPMessageCreateRequest(kCFAllocatorDefault, requestMethod, requestURL, kCFHTTPVersion1_1);
+    CFHTTPMessageSetBody(cfrequest, bodyData);
+    CFHTTPMessageSetHeaderFieldValue(cfrequest, requestHeader, requestHeaderValue);
+    
+    CFReadStreamRef readStream=CFReadStreamCreateForHTTPRequest(kCFAllocatorDefault, cfrequest);
+    self.inputStream=(__bridge_transfer NSInputStream*)readStream;
+    NSString* host=[curRequest.allHTTPHeaderFields objectForKey:@"host"];
+    if (!host) {
+        host=curRequest.URL.host;
+    }
+    [_inputStream setProperty:NSStreamSocketSecurityLevelNegotiatedSSL forKey:NSStreamSocketSecurityLevelKey];
+    //    CFReadStreamSetProperty(readStream, (CFStringRef)NSStreamSocketSecurityLevelKey, kCFStreamSocketSecurityLevelNegotiatedSSL);
+    NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                   //                                   (id)kCFBooleanFalse, (id)kCFStreamSSLValidatesCertificateChain,
+                                   host,(__bridge id)kCFStreamSSLPeerName,
+                                   nil];
+    [_inputStream setProperty:sslProperties forKey:(__bridge_transfer NSString*)kCFStreamPropertySSLSettings];
+    [_inputStream setDelegate:self];
+    [_inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [_inputStream open];
+    
+    CFRelease(requestURL);
+    CFRelease(cfrequest);
+    CFRelease(requestBody);
+}
+/**
+ *  开始加载，在该方法中，加载一个请求
+ */
+- (void)startLoading {
+    NSMutableURLRequest * request = [self.request mutableCopy];
+    // 表示该请求已经被处理，防止无限循环
+    [NSURLProtocol setProperty:@(YES) forKey:protocolKey inRequest:request];
+    curRequest=request;
+    [self startRequest];
+}
+/**
+ *  取消请求
+ */
+- (void)stopLoading {
+    
+}
+
+-(void)handleResponse{
+    CFReadStreamRef readStream=(__bridge_retained CFReadStreamRef)_inputStream;
+    CFHTTPMessageRef message=(CFHTTPMessageRef)CFReadStreamCopyProperty(readStream, kCFStreamPropertyHTTPResponseHeader);
+    NSDictionary* headDict=(__bridge NSDictionary *)(CFHTTPMessageCopyAllHeaderFields(message));
+//    NSLog(@"response header is: %@",headDict[@"Location"]);
+    CFStringRef myStatusLine = CFHTTPMessageCopyResponseStatusLine(message);
+//    NSLog(@"response status line is: %@",myStatusLine);
+    CFIndex myErrCode = CFHTTPMessageGetResponseStatusCode(message);
+    NSLog(@"response status code is: %ld",myErrCode);
+    [_inputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [_inputStream setDelegate:nil];
+    [_inputStream close];
+    if (myErrCode>=200&&myErrCode<300) {
+        [self.client URLProtocol:self didLoadData:responseData];
+    }else if(myErrCode>=300&&myErrCode<400){
+        //重定向
+        responseData=[NSMutableData data];
+        // 为HTTPDNS服务设置降级机制
+        [[HttpDNS instance] setDelegateForDegradationFilter:(id<HttpDNSDegradationDelegate>)self];
+        NSString* location=headDict[@"Location"];
+        NSURL* url=[[NSURL alloc] initWithString:location];
+        NSString* ip=[[HttpDNS instance] getIpByHost:url.host];
+        curRequest=[[NSMutableURLRequest alloc] initWithURL:url];
+        if (ip) {
+            NSLog(@"Get IP from HTTPDNS Successfully!");
+            NSRange hostFirstRange = [location rangeOfString: url.host];
+            if (NSNotFound != hostFirstRange.location) {
+                NSString* newUrl = [location stringByReplacingCharactersInRange:hostFirstRange withString:ip];
+                curRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:newUrl]];
+                [curRequest setValue:url.host forHTTPHeaderField:@"host"];
+            }
+        }
+        [self startRequest];
+    }
+//    NSLog(@"response is: %@",[[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding]);
+}
+
+#pragma mark - NSStreamDelegate
+-(void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode{
+    if (eventCode==NSStreamEventHasSpaceAvailable||eventCode==NSStreamEventHasBytesAvailable) {
+        //通知nsurlconnection已收到response
+        CFReadStreamRef readStream=(__bridge_retained CFReadStreamRef)_inputStream;
+        CFHTTPMessageRef message=(CFHTTPMessageRef)CFReadStreamCopyProperty(readStream, kCFStreamPropertyHTTPResponseHeader);
+        NSDictionary* headDict=(__bridge NSDictionary *)(CFHTTPMessageCopyAllHeaderFields(message));
+        NSURLResponse* response=[[NSURLResponse alloc] initWithURL:self.request.URL MIMEType:headDict[@"Content-Type"] expectedContentLength:headDict[@"Content-Length"] textEncodingName:@"UTF8"];
+        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+        
+        //验证证书
+        NSArray *certs = [_inputStream propertyForKey: (__bridge NSString *)kCFStreamPropertySSLPeerCertificates];
+        SecTrustRef trust = (__bridge SecTrustRef)[_inputStream propertyForKey: (__bridge NSString *)kCFStreamPropertySSLPeerTrust];
+        NSNumber *alreadyAdded = [_inputStream propertyForKey: kAnchorAlreadyAdded];
+        if (!alreadyAdded || ![alreadyAdded boolValue]) {
+            [_inputStream setProperty: [NSNumber numberWithBool: YES] forKey: kAnchorAlreadyAdded];
+        }
+        SecTrustResultType res = kSecTrustResultInvalid;
+//        NSMutableArray *policies = [NSMutableArray array];
+//        NSString* domain=[[self.request allHTTPHeaderFields] valueForKey:@"host"];
+//        if (domain) {
+//            [policies addObject:(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)domain)];
+//        } else {
+//            [policies addObject:(__bridge_transfer id)SecPolicyCreateBasicX509()];
+//        }
+        /*
+         * 绑定校验策略到服务端的证书上
+         */
+//        SecTrustSetPolicies(trust, (__bridge CFArrayRef)policies);
+        if (SecTrustEvaluate(trust, &res)!= errSecSuccess) {
+            [_inputStream removeFromRunLoop: [NSRunLoop currentRunLoop] forMode: NSRunLoopCommonModes];
+            [_inputStream setDelegate: nil];
+            [_inputStream close];
+        }
+        if (res != kSecTrustResultProceed && res != kSecTrustResultUnspecified) {
+            /* The host is not trusted. */
+            /* Tear down the input stream. */
+            [_inputStream removeFromRunLoop: [NSRunLoop currentRunLoop] forMode: NSRunLoopCommonModes];
+            [_inputStream setDelegate: nil];
+            [_inputStream close];
+            
+            /* Tear down the output stream. */
+            
+            
+        } else {
+            // Host is trusted.  Handle the data callback normally.
+            if (!responseData) {
+                responseData=[NSMutableData data];
+            }
+            UInt8 buffer[2048];
+            //回调读取数据时，读取的都是body的内容，response header自动被封装处理好的。
+            NSInputStream* inputstream=(NSInputStream*)aStream;
+            CFIndex length = [inputstream read:buffer maxLength:sizeof(buffer)];
+            [responseData appendBytes:buffer length:length];
+        }
+    }else if(eventCode==NSStreamEventErrorOccurred){
+        [_inputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+        [_inputStream setDelegate:nil];
+        [_inputStream close];
+        NSError *underlyingError = CFBridgingRelease(CFReadStreamCopyError((CFReadStreamRef)_inputStream));
+        [self.client URLProtocol:self didFailWithError:underlyingError];
+    }else if(eventCode==NSStreamEventEndEncountered){
+        [self handleResponse];
+    }
+}
+/*
+ * 降级过滤器，您可以自己定义HTTPDNS降级机制
+ */
+- (BOOL)shouldDegradeHTTPDNS:(NSString *)hostName {
+    NSLog(@"Enters Degradation filter.");
+    // 根据HTTPDNS使用说明，存在网络代理情况下需降级为Local DNS
+    if ([NetworkManager configureProxies]) {
+        NSLog(@"Proxy was set. Degrade!");
+        return YES;
+    }
+    
+    // 假设您禁止"www.taobao.com"域名通过HTTPDNS进行解析
+    if ([hostName isEqualToString:@"www.taobao.com"]) {
+        NSLog(@"The host is in blacklist. Degrade!");
+        return YES;
+    }
+    
+    return NO;
+}
+
+@end

--- a/httpdns_api_demo/httpdns_api_demo/source/NSURLConnection+HttpsExtension.h
+++ b/httpdns_api_demo/httpdns_api_demo/source/NSURLConnection+HttpsExtension.h
@@ -1,0 +1,13 @@
+//
+//  MyURLConnection.h
+//  httpdns_api_demo
+//
+//  Created by DaveLam on 16/6/5.
+//  Copyright © 2016年 com.aliyun.mobile. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSURLConnection(HttpsExtension)
+
+@end

--- a/httpdns_api_demo/httpdns_api_demo/source/NSURLConnection+HttpsExtension.m
+++ b/httpdns_api_demo/httpdns_api_demo/source/NSURLConnection+HttpsExtension.m
@@ -1,0 +1,89 @@
+//
+//  MyURLConnection.m
+//  httpdns_api_demo
+//
+//  Created by DaveLam on 16/6/5.
+//  Copyright © 2016年 com.aliyun.mobile. All rights reserved.
+//
+
+#import "NSURLConnection+HttpsExtension.h"
+
+@implementation NSURLConnection(HttpsExtension)
+
+- (BOOL)evaluateServerTrust:(SecTrustRef)serverTrust
+                  forDomain:(NSString *)domain
+{
+    /*
+     * 创建证书校验策略
+     */
+    NSMutableArray *policies = [NSMutableArray array];
+    if (domain) {
+        [policies addObject:(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)domain)];
+    } else {
+        [policies addObject:(__bridge_transfer id)SecPolicyCreateBasicX509()];
+    }
+    
+    /*
+     * 绑定校验策略到服务端的证书上
+     */
+    SecTrustSetPolicies(serverTrust, (__bridge CFArrayRef)policies);
+    
+    
+    /*
+     * 评估当前serverTrust是否可信任，
+     * 官方建议在result = kSecTrustResultUnspecified 或 kSecTrustResultProceed
+     * 的情况下serverTrust可以被验证通过，https://developer.apple.com/library/ios/technotes/tn2232/_index.html
+     * 关于SecTrustResultType的详细信息请参考SecTrust.h
+     */
+    SecTrustResultType result;
+    SecTrustEvaluate(serverTrust, &result);
+    
+    return (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
+}
+/*
+ * NSURLConnection
+ */
+- (void)hda_connection:(NSURLConnection *)connection
+willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
+{
+    if (!challenge) {
+        return;
+    }
+    
+    /*
+     * URL里面的host在使用HTTPDNS的情况下被设置成了IP，此处从HTTP Header中获取真实域名
+     */
+//    NSString* host = [[self.request allHTTPHeaderFields] objectForKey:@"host"];
+//    if (!host) {
+//        host = self.request.URL.host;
+//    }
+    NSString* host=@"www.aliyun.com";
+    
+    
+    /*
+     * 判断challenge的身份验证方法是否是NSURLAuthenticationMethodServerTrust（HTTPS模式下会进行该身份验证流程），
+     * 在没有配置身份验证方法的情况下进行默认的网络请求流程。
+     */
+    if ([challenge.protectionSpace.authenticationMethod isEqualToString:NSURLAuthenticationMethodServerTrust])
+    {
+        if ([self evaluateServerTrust:challenge.protectionSpace.serverTrust forDomain:host]) {
+            /*
+             * 验证完以后，需要构造一个NSURLCredential发送给发起方
+             */
+            NSURLCredential *credential = [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust];
+            [[challenge sender] useCredential:credential forAuthenticationChallenge:challenge];
+        } else {
+            /*
+             * 验证失败，取消这次验证流程
+             */
+            [[challenge sender] cancelAuthenticationChallenge:challenge];
+        }
+    } else {
+        /*
+         * 对于其他验证方法直接进行处理流程
+         */
+        [[challenge sender] continueWithoutCredentialForAuthenticationChallenge:challenge];
+    }
+}
+
+@end

--- a/httpdns_ios_demo/httpdns_ios_demo.xcodeproj/project.pbxproj
+++ b/httpdns_ios_demo/httpdns_ios_demo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		947191F01CEDAAA500E13DE9 /* CoreTelephony.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 947191EF1CEDAAA500E13DE9 /* CoreTelephony.framework */; };
 		94AE71BE1CDB9C3100EE4BBF /* UTDID.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94AE71BD1CDB9C3100EE4BBF /* UTDID.framework */; };
 		E2552B8C1C7F167A00D46C32 /* AlicloudHttpDNS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E2552B8B1C7F167A00D46C32 /* AlicloudHttpDNS.framework */; };
+		F7F97DFC1D152A0D00646D3F /* CFHttpMessageURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F97DFB1D152A0D00646D3F /* CFHttpMessageURLProtocol.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -41,6 +42,8 @@
 		947191EF1CEDAAA500E13DE9 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		94AE71BD1CDB9C3100EE4BBF /* UTDID.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = UTDID.framework; sourceTree = "<group>"; };
 		E2552B8B1C7F167A00D46C32 /* AlicloudHttpDNS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AlicloudHttpDNS.framework; sourceTree = "<group>"; };
+		F7F97DFA1D152A0D00646D3F /* CFHttpMessageURLProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CFHttpMessageURLProtocol.h; sourceTree = "<group>"; };
+		F7F97DFB1D152A0D00646D3F /* CFHttpMessageURLProtocol.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CFHttpMessageURLProtocol.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +88,8 @@
 		942188E91C59011B00696D6E /* httpdns_ios_demo */ = {
 			isa = PBXGroup;
 			children = (
+				F7F97DFA1D152A0D00646D3F /* CFHttpMessageURLProtocol.h */,
+				F7F97DFB1D152A0D00646D3F /* CFHttpMessageURLProtocol.m */,
 				942188ED1C59011B00696D6E /* AppDelegate.h */,
 				942188EE1C59011B00696D6E /* AppDelegate.m */,
 				942188F01C59011B00696D6E /* ViewController.h */,
@@ -178,6 +183,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F7F97DFC1D152A0D00646D3F /* CFHttpMessageURLProtocol.m in Sources */,
 				942189051C59041100696D6E /* NetworkManager.m in Sources */,
 				942188F21C59011B00696D6E /* ViewController.m in Sources */,
 				942188EF1C59011B00696D6E /* AppDelegate.m in Sources */,

--- a/httpdns_ios_demo/httpdns_ios_demo/AppDelegate.m
+++ b/httpdns_ios_demo/httpdns_ios_demo/AppDelegate.m
@@ -7,6 +7,7 @@
 //
 
 #import "AppDelegate.h"
+#import "CFHttpMessageURLProtocol.h"
 
 @interface AppDelegate ()
 
@@ -17,6 +18,8 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Override point for customization after application launch.
+    //SNI场景设置
+    [NSURLProtocol registerClass:[CFHttpMessageURLProtocol class]];
     return YES;
 }
 

--- a/httpdns_ios_demo/httpdns_ios_demo/Base.lproj/Main.storyboard
+++ b/httpdns_ios_demo/httpdns_ios_demo/Base.lproj/Main.storyboard
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>

--- a/httpdns_ios_demo/httpdns_ios_demo/CFHttpMessageURLProtocol.h
+++ b/httpdns_ios_demo/httpdns_ios_demo/CFHttpMessageURLProtocol.h
@@ -1,0 +1,13 @@
+//
+//  MyCFHttpMessageURLProtocol.h
+//  NSURLProtocolDemo
+//
+//  Created by fuyuan.lfy on 16/6/14.
+//  Copyright © 2016年 Jaylon. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CFHttpMessageURLProtocol : NSURLProtocol
+
+@end

--- a/httpdns_ios_demo/httpdns_ios_demo/CFHttpMessageURLProtocol.m
+++ b/httpdns_ios_demo/httpdns_ios_demo/CFHttpMessageURLProtocol.m
@@ -1,0 +1,272 @@
+//
+//  MyCFHttpMessageURLProtocol.m
+//  NSURLProtocolDemo
+//
+//  Created by fuyuan.lfy on 16/6/14.
+//  Copyright © 2016年 Jaylon. All rights reserved.
+//
+
+#import "CFHttpMessageURLProtocol.h"
+#import <AlicloudHttpDNS/Httpdns.h>
+#import "NetworkManager.h"
+
+#define protocolKey @"CFHttpMessagePropertyKey"
+#define kAnchorAlreadyAdded @"AnchorAlreadyAdded"
+
+@interface CFHttpMessageURLProtocol()<NSStreamDelegate,HttpDNSDegradationDelegate>{
+    NSMutableData* responseData;
+    NSMutableURLRequest* curRequest;
+}
+
+@property(strong,nonatomic)NSInputStream* inputStream;
+
+@end
+
+@implementation CFHttpMessageURLProtocol
+
+/**
+ *  是否拦截处理指定的请求
+ *
+ *  @param request 指定的请求
+ *
+ *  @return 返回YES表示要拦截处理，返回NO表示不拦截处理
+ */
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+    
+    /*
+     防止无限循环，因为一个请求在被拦截处理过程中，也会发起一个请求，这样又会走到这里，如果不进行处理，就会造成无限循环
+     */
+    if ([NSURLProtocol propertyForKey:protocolKey inRequest:request]) {
+        return NO;
+    }
+    
+    NSString * url = request.URL.absoluteString;
+    
+    // 如果url已http或https开头，则进行拦截处理，否则不处理
+    if ([url hasPrefix:@"https"]) {
+        return YES;
+    }
+    return NO;
+}
+
+/**
+ *  如果需要对请求进行重定向，添加指定头部等操作，可以在该方法中进行
+ *
+ *  @param request 原请求
+ *
+ *  @return 修改后的请求
+ */
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+    return request;
+}
+/**
+ *  开始加载，在该方法中，加载一个请求
+ */
+- (void)startLoading {
+    NSMutableURLRequest * request = [self.request mutableCopy];
+    // 表示该请求已经被处理，防止无限循环
+    [NSURLProtocol setProperty:@(YES) forKey:protocolKey inRequest:request];
+    curRequest=request;
+    [self startRequest];
+}
+/**
+ *  取消请求
+ */
+- (void)stopLoading {
+    [self.client URLProtocol:self didFailWithError:[[NSError alloc] initWithDomain:@"stop loading" code:-1 userInfo:nil]];
+}
+
+/**
+ *  使用CFHTTPMessage转发请求
+ */
+-(void)startRequest{
+    //使用IP访问，必须在HTTP头部域设置host
+    CFStringRef requestHeader=CFSTR("host");
+    CFStringRef requestHeaderValue=(__bridge CFStringRef)[[curRequest allHTTPHeaderFields] valueForKey:@"host"];
+    
+    //添加http post请求所附带的数据
+    CFStringRef requestBody=CFSTR("");
+    CFDataRef bodyData=CFStringCreateExternalRepresentation(kCFAllocatorDefault, requestBody, kCFStringEncodingUTF8, 0);
+    if (curRequest.HTTPBody) {
+        bodyData=(__bridge_retained CFDataRef)curRequest.HTTPBody;
+    }
+//    CFDataRef bodyData=CFStringCreateExternalRepresentation(kCFAllocatorDefault, requestBody, kCFStringEncodingUTF8, 0);
+    
+    CFStringRef url=(__bridge CFStringRef)[curRequest.URL absoluteString];
+    CFURLRef requestURL=CFURLCreateWithString(kCFAllocatorDefault, url, NULL);
+    
+    //原请求所使用的方法，GET或POST
+    CFStringRef requestMethod=(__bridge_retained CFStringRef)curRequest.HTTPMethod;
+    
+    //根据请求的url、方法、版本创建CFHTTPMessageRef对象
+    CFHTTPMessageRef cfrequest=CFHTTPMessageCreateRequest(kCFAllocatorDefault, requestMethod, requestURL, kCFHTTPVersion1_1);
+    CFHTTPMessageSetBody(cfrequest, bodyData);
+    CFHTTPMessageSetHeaderFieldValue(cfrequest, requestHeader, requestHeaderValue);
+    
+    //创建CFHTTPMessage对象的输入流，设置SSL验证参数
+    CFReadStreamRef readStream=CFReadStreamCreateForHTTPRequest(kCFAllocatorDefault, cfrequest);
+    self.inputStream=(__bridge_transfer NSInputStream*)readStream;
+    
+    //设置SNI host信息，关键步骤
+    NSString* host=[curRequest.allHTTPHeaderFields objectForKey:@"host"];
+    if (!host) {
+        host=curRequest.URL.host;
+    }
+    [_inputStream setProperty:NSStreamSocketSecurityLevelNegotiatedSSL forKey:NSStreamSocketSecurityLevelKey];
+    NSDictionary *sslProperties = [[NSDictionary alloc] initWithObjectsAndKeys:
+                                   host,(__bridge id)kCFStreamSSLPeerName,
+                                   nil];
+    [_inputStream setProperty:sslProperties forKey:(__bridge_transfer NSString*)kCFStreamPropertySSLSettings];
+    [_inputStream setDelegate:self];
+    
+    //将请求放入当前runloop的事件队列
+    [_inputStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [_inputStream open];
+    
+    CFRelease(requestURL);
+    CFRelease(cfrequest);
+    CFRelease(requestBody);
+}
+
+/**
+ *  根据服务器返回的响应内容进行不同的处理
+ */
+-(void)handleResponse{
+    //获取响应头部信息
+    CFReadStreamRef readStream = (__bridge_retained CFReadStreamRef)_inputStream;
+    CFHTTPMessageRef message = (CFHTTPMessageRef)CFReadStreamCopyProperty(readStream, kCFStreamPropertyHTTPResponseHeader);
+    NSDictionary* headDict = (__bridge NSDictionary *)(CFHTTPMessageCopyAllHeaderFields(message));
+//    CFStringRef myStatusLine = CFHTTPMessageCopyResponseStatusLine(message);
+    
+    //获取响应头部的状态码
+    CFIndex myErrCode = CFHTTPMessageGetResponseStatusCode(message);
+    NSLog(@"response status code is: %ld",myErrCode);
+    
+    //把当前请求关闭
+    [_inputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    [_inputStream setDelegate:nil];
+    [_inputStream close];
+    
+    if (myErrCode >= 200 && myErrCode < 300) {
+        
+        //返回码为2xx，直接通知client
+        [self.client URLProtocol:self didLoadData:responseData];
+        
+    }else if(myErrCode>=300&&myErrCode<400){
+        //返回码为3xx，需要重定向请求，继续访问重定向页面
+        NSURLResponse* response=[[NSURLResponse alloc] initWithURL:curRequest.URL MIMEType:headDict[@"Content-Type"] expectedContentLength:[headDict[@"Content-Length"] integerValue] textEncodingName:@"UTF8"];
+        [self.client URLProtocol:self wasRedirectedToRequest:curRequest redirectResponse:response];
+        responseData=[NSMutableData data];
+        // 为HTTPDNS服务设置降级机制
+        [[HttpDnsService sharedInstance] setDelegateForDegradationFilter:(id<HttpDNSDegradationDelegate>)self];
+        
+        //获取重定向页面的url，并将url中的host通过HTTPDNS转换为IP
+        NSString* location=headDict[@"Location"];
+        NSURL* url=[[NSURL alloc] initWithString:location];
+        NSString* ip=[[HttpDnsService sharedInstance] getIpByHost:url.host];
+        curRequest=[[NSMutableURLRequest alloc] initWithURL:url];
+        if (ip) {
+            NSLog(@"Get IP from HTTPDNS Successfully!");
+            NSRange hostFirstRange = [location rangeOfString: url.host];
+            if (NSNotFound != hostFirstRange.location) {
+                NSString* newUrl = [location stringByReplacingCharactersInRange:hostFirstRange withString:ip];
+                curRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:newUrl]];
+                [curRequest setValue:url.host forHTTPHeaderField:@"host"];
+            }
+        }
+        [self startRequest];
+    }else{
+        //其他情况，直接返回响应信息给client
+        [self.client URLProtocol:self didLoadData:responseData];
+    }
+//    CFRelease(readStream);
+//    CFRelease(message);
+}
+
+#pragma mark - NSStreamDelegate
+-(void)stream:(NSStream *)aStream handleEvent:(NSStreamEvent)eventCode{
+    if (eventCode==NSStreamEventHasSpaceAvailable||eventCode==NSStreamEventHasBytesAvailable) {
+        //通知nsurlconnection已收到response
+        CFReadStreamRef readStream=(__bridge_retained CFReadStreamRef)_inputStream;
+        CFHTTPMessageRef message=(CFHTTPMessageRef)CFReadStreamCopyProperty(readStream, kCFStreamPropertyHTTPResponseHeader);
+        NSDictionary* headDict=(__bridge NSDictionary *)(CFHTTPMessageCopyAllHeaderFields(message));
+//        NSURLResponse* response = (__bridge_transfer NSURLResponse*)message;
+        NSURLResponse* response=[[NSURLResponse alloc] initWithURL:self.request.URL MIMEType:headDict[@"Content-Type"] expectedContentLength:[headDict[@"Content-Length"] integerValue] textEncodingName:@"UTF8"];
+        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+        
+        //验证证书
+//        NSArray *certs = [_inputStream propertyForKey: (__bridge NSString *)kCFStreamPropertySSLPeerCertificates];
+        SecTrustRef trust = (__bridge SecTrustRef)[_inputStream propertyForKey: (__bridge NSString *)kCFStreamPropertySSLPeerTrust];
+        NSNumber *alreadyAdded = [_inputStream propertyForKey: kAnchorAlreadyAdded];
+        if (!alreadyAdded || ![alreadyAdded boolValue]) {
+            [_inputStream setProperty: [NSNumber numberWithBool: YES] forKey: kAnchorAlreadyAdded];
+        }
+        SecTrustResultType res = kSecTrustResultInvalid;
+//        NSMutableArray *policies = [NSMutableArray array];
+//        NSString* domain=[[self.request allHTTPHeaderFields] valueForKey:@"host"];
+//        if (domain) {
+//            [policies addObject:(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)domain)];
+//        } else {
+//            [policies addObject:(__bridge_transfer id)SecPolicyCreateBasicX509()];
+//        }
+        /*
+         * 绑定校验策略到服务端的证书上
+         */
+//        SecTrustSetPolicies(trust, (__bridge CFArrayRef)policies);
+        if (SecTrustEvaluate(trust, &res)!= errSecSuccess) {
+            [_inputStream removeFromRunLoop: [NSRunLoop currentRunLoop] forMode: NSRunLoopCommonModes];
+            [_inputStream setDelegate: nil];
+            [_inputStream close];
+        }
+        if (res != kSecTrustResultProceed && res != kSecTrustResultUnspecified) {
+            /* The host is not trusted. */
+            /* Tear down the input stream. */
+            [_inputStream removeFromRunLoop: [NSRunLoop currentRunLoop] forMode: NSRunLoopCommonModes];
+            [_inputStream setDelegate: nil];
+            [_inputStream close];
+            
+        } else {
+            // Host is trusted.  Handle the data callback normally.
+            if (!responseData) {
+                responseData=[NSMutableData data];
+            }
+            UInt8 buffer[2048];
+            //回调读取数据时，读取的都是body的内容，response header自动被封装处理好的。
+            NSInputStream* inputstream=(NSInputStream*)aStream;
+            CFIndex length = [inputstream read:buffer maxLength:sizeof(buffer)];
+            [responseData appendBytes:buffer length:length];
+        }
+    }else if(eventCode==NSStreamEventErrorOccurred){
+        [_inputStream removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+        [_inputStream setDelegate:nil];
+        [_inputStream close];
+        //通知client发生错误了
+        NSError *underlyingError = CFBridgingRelease(CFReadStreamCopyError((CFReadStreamRef)_inputStream));
+        [self.client URLProtocol:self didFailWithError:underlyingError];
+    }else if(eventCode==NSStreamEventEndEncountered){
+        [self handleResponse];
+    }
+}
+
+#pragma mark - HttpDNSDegradationDelegate
+/*
+ * 降级过滤器，您可以自己定义HTTPDNS降级机制
+ */
+- (BOOL)shouldDegradeHTTPDNS:(NSString *)hostName {
+    NSLog(@"Enters Degradation filter.");
+    // 根据HTTPDNS使用说明，存在网络代理情况下需降级为Local DNS
+    if ([NetworkManager configureProxies]) {
+        NSLog(@"Proxy was set. Degrade!");
+        return YES;
+    }
+    
+    // 假设您禁止"www.taobao.com"域名通过HTTPDNS进行解析
+    if ([hostName isEqualToString:@"www.taobao.com"]) {
+        NSLog(@"The host is in blacklist. Degrade!");
+        return YES;
+    }
+    
+    return NO;
+}
+
+@end

--- a/httpdns_ios_demo/httpdns_ios_demo/ViewController.m
+++ b/httpdns_ios_demo/httpdns_ios_demo/ViewController.m
@@ -31,7 +31,8 @@ static HttpDnsService *httpdns;
     // 为HTTPDNS服务设置降级机制
     [httpdns setDelegateForDegradationFilter:(id<HttpDNSDegradationDelegate>)self];
     
-    NSArray *preResolveHosts = @[@"www.aliyun.com", @"www.taobao.com", @"gw.alicdn.com"];
+    //edited
+    NSArray *preResolveHosts = @[@"www.aliyun.com", @"www.taobao.com", @"gw.alicdn.com", @"www.tmall.com"];
     // 设置预解析域名列表
     [httpdns setPreResolveHosts:preResolveHosts];
     

--- a/httpdns_ios_demo/httpdns_ios_demo/ViewController.m
+++ b/httpdns_ios_demo/httpdns_ios_demo/ViewController.m
@@ -26,7 +26,7 @@ static HttpDnsService *httpdns;
     httpdns = [HttpDnsService sharedInstance];
     
     // 设置AccoutID
-    [httpdns setAccountID:100000];
+    [httpdns setAccountID:139450];
     
     // 为HTTPDNS服务设置降级机制
     [httpdns setDelegateForDegradationFilter:(id<HttpDNSDegradationDelegate>)self];
@@ -39,7 +39,7 @@ static HttpDnsService *httpdns;
     // 异步网络请求
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         
-        NSString *originalUrl = @"http://www.aliyun.com/";
+        NSString *originalUrl = @"https://dou.bz/23o8PS";
         NSURL* url = [NSURL URLWithString:originalUrl];
         NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:url];
         // 同步接口获取IP地址，由于我们是用来进行url访问请求的，为了适配IPv6的使用场景，我们使用getIpByHostInURLFormat接口


### PR DESCRIPTION
1.使用了NSURLProtocol + CFHttpMessage，通过设置kCFStreamSSLPeerName来设置SNI
2.在CFHttpMessage请求中，如果原域名返回码为3xx，将继续请求重定向页面，直至返回码为2xx
